### PR TITLE
fixed leaderboard sorting improperly

### DIFF
--- a/PuckdropClient/src/app/league-standings-table/league-standings-table.component.ts
+++ b/PuckdropClient/src/app/league-standings-table/league-standings-table.component.ts
@@ -61,9 +61,10 @@ export class LeagueStandingsTableComponent implements OnInit {
       records.forEach(function (rec) {
         newArr = newArr.concat(rec.teamRecords)
       }); 
-      this.newStandings = newArr.sort((a, b) => (a.points > b.points) ? -1 : 1);
+      this.newStandings = newArr.sort((a, b) => (parseInt(a.leagueRank) > parseInt(b.leagueRank)) ? 1 : -1);
     } else {
-      this.newStandings = this.rawStandings.records[this.focusedDivision].teamRecords.sort((a, b) => (a.leagueRank > b.leagueRank) ? -1 : 1)
+      console.log(this.rawStandings.records[this.focusedDivision].teamRecords);
+      this.newStandings = this.rawStandings.records[this.focusedDivision].teamRecords.sort((a, b) => (parseInt(a.leagueRank) > parseInt(b.leagueRank)) ? 1 : -1)
     }
     console.log(this.newStandings);
   }


### PR DESCRIPTION
1. Was sorting by points instead of leagueRank (Can be a problem in cases where points are tied)
2. Sorting by points is opposite of sorting by ranking (large numbers better for points, but not ranking)